### PR TITLE
Fix heartbeat schema checks

### DIFF
--- a/uptime/check_funcs.go
+++ b/uptime/check_funcs.go
@@ -51,16 +51,18 @@ func getCommonCheckAttrs(d *schema.ResourceData, c *uptime.Check) {
 
 func checkBuildFunc(ct CheckType) func(d *schema.ResourceData) *uptime.Check {
 	return func(d *schema.ResourceData) *uptime.Check {
-		check := &uptime.Check{
+		check := uptime.Check{
 			CheckType:     ct.typeStr(),
-			Address:       d.Get("address").(string),
 			ContactGroups: expandSetAttr(d.Get("contact_groups")),
 		}
+		if ct.typeStr() != "Heartbeat" {
+			check.Address = d.Get("address").(string)
+		}
 
-		getCommonCheckAttrs(d, check)
-		ct.getSpecificAttrs(d, check)
+		getCommonCheckAttrs(d, &check)
+		ct.getSpecificAttrs(d, &check)
 
-		return check
+		return &check
 	}
 }
 


### PR DESCRIPTION
Avoid consistent error for incorrectly expecting "address" schema value when setting up heartbeat, as this resource doesn't specify that key in its [schema](https://github.com/uptime-com/terraform-provider-uptime/blob/master/uptime/resource_uptime_check_heartbeat.go#L17-L66).