### PR TITLE
[ UP-3357 ] Handle empty default status code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.9.0
-	github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240415154944-54fa3a069e1d
+	github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240507095204-b02a9efffaf9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240415154944-54fa3a069e1d h1:Y0kW+xuJdxXyu6UpQE0mZTvI/n3OJgPm4f1Rwf5/kgU=
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240415154944-54fa3a069e1d/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
+github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240507095204-b02a9efffaf9 h1:UD3knB1Mu7UUgP8BqfLxK/u+RrjqCoARvPgnzyJBrvI=
+github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240507095204-b02a9efffaf9/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resource_check_http.go
+++ b/internal/provider/resource_check_http.go
@@ -63,7 +63,7 @@ func NewCheckHTTPResource(_ context.Context, p *providerImpl) resource.Resource 
 					"status_code": schema.StringAttribute{
 						Optional: true,
 						Computed: true,
-						Default:  stringdefault.StaticString("200"),
+						Default:  stringdefault.StaticString(""),
 					},
 					"send_string": schema.StringAttribute{
 						Optional:    true,


### PR DESCRIPTION
For HTTP checks, the status code can be empty.
The API considers an empty value as a special case when creating a check that follows redirects and verifies that the last response returns a 200 status code.

https://uptimedotcom.atlassian.net/browse/UP-3357