### PR TITLE
fix: SYS-396 make contact_group mandatory for group checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.9.0
-	github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240909144813-ed02ddd58c28
+	github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240923125115-4ea7a832ad8a
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240909143903-2201e1ed51bd h1:
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240909143903-2201e1ed51bd/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240909144813-ed02ddd58c28 h1:m8H8Q1ZXZEZQk74afxryN2NuRLuMEWi6oB/KjAl7evU=
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240909144813-ed02ddd58c28/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
+github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240923125115-4ea7a832ad8a h1:xJnjw75PWdpgAXwr+Z9c0puSaizO/fo78sfSUlvn0wQ=
+github.com/uptime-com/uptime-client-go/v2 v2.0.0-20240923125115-4ea7a832ad8a/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resource_check_group_test.go
+++ b/internal/provider/resource_check_group_test.go
@@ -56,3 +56,36 @@ func TestAccCheckGroupResource_ResponseTime(t *testing.T) {
 		},
 	}))
 }
+
+func TestAccCheckGroupResource_PercentCalculation(t *testing.T) {
+	names := []string{
+		petname.Generate(3, "-"),
+		petname.Generate(3, "-"),
+	}
+	resource.Test(t, testCaseFromSteps(t, []resource.TestStep{
+		{
+			ConfigVariables: config.Variables{
+				"name":                       config.StringVariable(names[0]),
+				"uptime_percent_calculation": config.StringVariable("UP_DOWN_STATES"),
+			},
+			ConfigDirectory: config.StaticDirectory("testdata/resource_check_group/percent_calculation"),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("uptime_check_group.test", "name", names[0]),
+				resource.TestCheckResourceAttr("uptime_check_group.test", "config.response_time.check_type", "HTTP"),
+				resource.TestCheckResourceAttr("uptime_check_group.test", "config.uptime_percent_calculation", "UP_DOWN_STATES"),
+			),
+		},
+		{
+			ConfigVariables: config.Variables{
+				"name":                       config.StringVariable(names[1]),
+				"uptime_percent_calculation": config.StringVariable("AVERAGE"),
+			},
+			ConfigDirectory: config.StaticDirectory("testdata/resource_check_group/percent_calculation"),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("uptime_check_group.test", "name", names[1]),
+				resource.TestCheckResourceAttr("uptime_check_group.test", "config.response_time.check_type", "HTTP"),
+				resource.TestCheckResourceAttr("uptime_check_group.test", "config.uptime_percent_calculation", "AVERAGE"),
+			),
+		},
+	}))
+}

--- a/internal/provider/testdata/resource_check_group/percent_calculation/main.tf
+++ b/internal/provider/testdata/resource_check_group/percent_calculation/main.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type = string
+}
+
+variable "uptime_percent_calculation" {
+  type = string
+}
+
+resource "uptime_check_group" "test" {
+  name   = var.name
+  config = {
+    uptime_percent_calculation = var.uptime_percent_calculation
+  }
+  contact_groups = []
+}


### PR DESCRIPTION
Dependency https://github.com/uptime-com/uptime-client-go/pull/15