### PR TITLE
Support IPv6 for hostname validation

### DIFF
--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -70,7 +70,7 @@ type hostnameValidator struct {
 	zoyaDescriber
 }
 
-var hostnameRE = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])`)
+var hostnameRE = regexp.MustCompile(`^(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}|(?:\d{1,3}\.){3}\d{1,3}|(?:[a-fA-F0-9:]+:+)+[a-fA-F0-9]+)$`)
 
 func (hostnameValidator) ValidateString(_ context.Context, rq validator.StringRequest, rs *validator.StringResponse) {
 	if rq.ConfigValue.IsNull() {


### PR DESCRIPTION
The hostname validation must be updated to support IPv6 values ICMP check addresses. The current regex expression does not accept IPv6 values.

This PR will fix #120 