### PR TITLE
fix: SYS-411 dashboard update service selected

### DIFF
--- a/docs/resources/statuspage_incident.md
+++ b/docs/resources/statuspage_incident.md
@@ -18,18 +18,18 @@ Status page incident or maintenance window resource
 ### Required
 
 - `name` (String)
+- `starts_at` (String) When this incident occurred in GMT
 - `statuspage_id` (Number)
 - `updates` (Attributes Set) (see [below for nested schema](#nestedatt--updates))
 
 ### Optional
 
 - `affected_components` (Attributes Set) (see [below for nested schema](#nestedatt--affected_components))
-- `ends_at` (String)
+- `ends_at` (String) When this incident ended in GMT
 - `incident_type` (String)
 - `include_in_global_metrics` (Boolean)
 - `notify_subscribers` (Boolean)
 - `send_maintenance_start_notification` (Boolean)
-- `starts_at` (String)
 - `update_component_status` (Boolean)
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.10.0
-	github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250129120822-0b5cdab5a237
+	github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250204102900-bf921a284c6c
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.10.0
-	github.com/uptime-com/uptime-client-go/v2 v2.0.0-20241204093759-45854fa6a664
+	github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250129120822-0b5cdab5a237
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20241204093759-45854fa6a664 h1:IphsKMPkm6/EQryzDZtfYxImHyk/HnCkJs1MtkB7NGU=
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20241204093759-45854fa6a664/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
+github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250129120822-0b5cdab5a237 h1:gKGLyvA++F4/ahMzpPRogPOEf66nvpFHvzax4X9wzmA=
+github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250129120822-0b5cdab5a237/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/uptime-com/uptime-client-go/v2 v2.0.0-20241204093759-45854fa6a664 h1:
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20241204093759-45854fa6a664/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250129120822-0b5cdab5a237 h1:gKGLyvA++F4/ahMzpPRogPOEf66nvpFHvzax4X9wzmA=
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250129120822-0b5cdab5a237/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
+github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250204102900-bf921a284c6c h1:A4BpYLHmGKESvsse1PJnoBij5KaYGyU1/MnkJWr0SKc=
+github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250204102900-bf921a284c6c/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -165,7 +165,7 @@ func NewDashboardResource(_ context.Context, p *providerImpl) resource.Resource 
 }
 
 type DashboardResourceModel struct {
-	ID       types.Int64  `tfsdk:"id" ref:"PK,opt"`
+	ID       types.Int64  `tfsdk:"id"`
 	Name     types.String `tfsdk:"name"`
 	Ordering types.Int64  `tfsdk:"ordering"`
 	IsPinned types.Bool   `tfsdk:"is_pinned"`
@@ -550,6 +550,7 @@ func (a DashboardResourceModelAdapter) Get(ctx context.Context, sg StateGetter) 
 
 func (a DashboardResourceModelAdapter) ToAPIArgument(model DashboardResourceModel) (*upapi.Dashboard, error) {
 	api := upapi.Dashboard{
+		PK:       model.ID.ValueInt64(),
 		Name:     model.Name.ValueString(),
 		IsPinned: model.IsPinned.ValueBool(),
 		Ordering: model.Ordering.ValueInt64(),
@@ -646,9 +647,7 @@ func (a DashboardResourceModelAdapter) FromAPIResult(api upapi.Dashboard) (*Dash
 		}
 		selectedAttribute.Tags = types.SetValueMust(types.StringType, selectedTags)
 	}
-	if len(selectedAttribute.Services.Elements()) > 0 || len(selectedAttribute.Tags.Elements()) > 0 {
-		model.Selected = a.SelectedAttributeValue(selectedAttribute)
-	}
+	model.Selected = a.SelectedAttributeValue(selectedAttribute)
 	return &model, nil
 }
 

--- a/internal/provider/resource_dashboard_test.go
+++ b/internal/provider/resource_dashboard_test.go
@@ -135,6 +135,26 @@ func TestAccDashboardResource_Alerts(t *testing.T) {
 				ConfigDirectory: config.StaticDirectory("testdata/resource_dashboard/alerts"),
 				ConfigVariables: config.Variables{
 					"name":                    config.StringVariable(name),
+					"alerts_show_section":     config.BoolVariable(true),
+					"alerts_for_all_checks":   config.BoolVariable(true),
+					"alerts_num_to_show":      config.IntegerVariable(5),
+					"alerts_include_ignored":  config.BoolVariable(true),
+					"alerts_include_resolved": config.BoolVariable(true),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptime_dashboard.alerts", "name", name),
+					resource.TestCheckResourceAttr("uptime_dashboard.alerts", "alerts.show_section", "true"),
+					resource.TestCheckResourceAttr("uptime_dashboard.alerts", "alerts.for_all_checks", "true"),
+					resource.TestCheckResourceAttr("uptime_dashboard.alerts", "alerts.num_to_show", "5"),
+					resource.TestCheckResourceAttr("uptime_dashboard.alerts", "alerts.include.ignored", "true"),
+					resource.TestCheckResourceAttr("uptime_dashboard.alerts", "alerts.include.resolved", "true"),
+					resource.TestCheckResourceAttr("uptime_dashboard.alerts", "selected.services.#", "0"),
+				),
+			},
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/resource_dashboard/alerts_selected"),
+				ConfigVariables: config.Variables{
+					"name":                    config.StringVariable(name),
 					"check_name":              config.StringVariable(name),
 					"alerts_show_section":     config.BoolVariable(true),
 					"alerts_for_all_checks":   config.BoolVariable(true),

--- a/internal/provider/resource_statuspage_incident.go
+++ b/internal/provider/resource_statuspage_incident.go
@@ -32,15 +32,16 @@ func NewStatusPageIncidentResource(_ context.Context, p *providerImpl) resource.
 					"id":   IDSchemaAttribute(),
 					"url":  URLSchemaAttribute(),
 					"name": NameSchemaAttribute(),
-					"ends_at": schema.StringAttribute{
-						Optional:   true,
-						Computed:   true,
-						CustomType: timetypes.RFC3339Type{},
-					},
 					"starts_at": schema.StringAttribute{
-						Optional:   true,
-						Computed:   true,
-						CustomType: timetypes.RFC3339Type{},
+						Description: "When this incident occurred in GMT",
+						Required:    true,
+						CustomType:  timetypes.RFC3339Type{},
+					},
+					"ends_at": schema.StringAttribute{
+						Description: "When this incident ended in GMT",
+						Optional:    true,
+						Computed:    true,
+						CustomType:  timetypes.RFC3339Type{},
 					},
 					"include_in_global_metrics": schema.BoolAttribute{
 						Optional: true,

--- a/internal/provider/resource_statuspage_incident_test.go
+++ b/internal/provider/resource_statuspage_incident_test.go
@@ -22,11 +22,13 @@ func TestAccStatusPageIncidentBasicResource(t *testing.T) {
 					"name":           config.StringVariable(name),
 					"incident_name":  config.StringVariable(incidentName),
 					"incident_state": config.StringVariable("investigating"),
+					"starts_at":      config.StringVariable("2025-01-28T00:00:00Z"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("uptime_statuspage.test", "name", name),
 					resource.TestCheckResourceAttr("uptime_statuspage_incident.test", "name", incidentName),
 					resource.TestCheckResourceAttr("uptime_statuspage_incident.test", "incident_type", "INCIDENT"),
+					resource.TestCheckResourceAttr("uptime_statuspage_incident.test", "starts_at", "2025-01-28T00:00:00Z"),
 				),
 			},
 			{
@@ -35,10 +37,12 @@ func TestAccStatusPageIncidentBasicResource(t *testing.T) {
 					"name":           config.StringVariable(name),
 					"incident_name":  config.StringVariable(incidentName),
 					"incident_state": config.StringVariable("monitoring"),
+					"starts_at":      config.StringVariable("2025-01-28T10:10:00Z"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("uptime_statuspage_incident.test", "updates.#", "1"),
 					resource.TestCheckResourceAttr("uptime_statuspage_incident.test", "updates.0.incident_state", "monitoring"),
+					resource.TestCheckResourceAttr("uptime_statuspage_incident.test", "starts_at", "2025-01-28T10:10:00Z"),
 				),
 			},
 		},
@@ -62,6 +66,7 @@ func TestAccStatusPageIncidentAffectedComponentsResource(t *testing.T) {
 					"check_name":                config.StringVariable(checkName),
 					"incident_state":            config.StringVariable("investigating"),
 					"incident_component_status": config.StringVariable("major-outage"),
+					"starts_at":                 config.StringVariable("2025-01-28T00:00:00Z"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("uptime_statuspage.test", "name", name),
@@ -71,6 +76,7 @@ func TestAccStatusPageIncidentAffectedComponentsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uptime_statuspage_incident.test", "affected_components.0.status", "major-outage",
 					),
+					resource.TestCheckResourceAttr("uptime_statuspage_incident.test", "starts_at", "2025-01-28T00:00:00Z"),
 				),
 			},
 		},

--- a/internal/provider/testdata/resource_dashboard/alerts_selected/main.tf
+++ b/internal/provider/testdata/resource_dashboard/alerts_selected/main.tf
@@ -2,6 +2,29 @@ variable "name" {
   type = string
 }
 
+variable "check_name" {
+  type = string
+}
+
+variable "script" {
+  type    = string
+  default = <<SCRIPT
+[
+  {
+    "step_def": "C_GET",
+    "values": {
+      "url": "https://example.com/"
+    }
+  }
+]
+SCRIPT
+}
+
+resource "uptime_check_api" "alerts" {
+  name   = var.check_name
+  script = var.script
+}
+
 variable "alerts_show_section" {
   type = bool
 }
@@ -23,6 +46,7 @@ variable "alerts_include_resolved" {
 }
 
 resource "uptime_dashboard" "alerts" {
+  depends_on = [uptime_check_api.alerts]
   name       = var.name
   alerts = {
     show           = var.alerts_show_section
@@ -38,6 +62,6 @@ resource "uptime_dashboard" "alerts" {
     show = {}
   }
   selected = {
-    services = []
+    services = [var.name]
   }
 }

--- a/internal/provider/testdata/resource_statuspage_incident/_basic/main.tf
+++ b/internal/provider/testdata/resource_statuspage_incident/_basic/main.tf
@@ -10,6 +10,10 @@ variable "incident_state" {
   type = string
 }
 
+variable "starts_at" {
+  type    = string
+}
+
 variable "ends_at" {
   type    = string
   default = null
@@ -23,6 +27,7 @@ resource "uptime_statuspage_incident" "test" {
   statuspage_id  = uptime_statuspage.test.id
   name           = var.incident_name
   incident_type  = "INCIDENT"
+  starts_at      = var.starts_at
   ends_at        = var.ends_at
   updates        = [
     {

--- a/internal/provider/testdata/resource_statuspage_incident/affected_components/main.tf
+++ b/internal/provider/testdata/resource_statuspage_incident/affected_components/main.tf
@@ -18,6 +18,10 @@ variable "incident_component_status" {
   type = string
 }
 
+variable "starts_at" {
+  type    = string
+}
+
 resource "uptime_check_api" "test" {
   name          = var.check_name
   script = <<SCRIPT
@@ -46,6 +50,7 @@ resource "uptime_statuspage_incident" "test" {
   statuspage_id  = uptime_statuspage.test.id
   name           = var.incident_name
   incident_type  = "INCIDENT"
+  starts_at      = var.starts_at
   updates        = [{
       incident_state = var.incident_state
   }]


### PR DESCRIPTION
The update doesn't work because the PATCH method of dashboard update from the uptime-go-client, uses zero value for PK.
PR dependency [givi-fix-dashboard-update-sys-411](https://github.com/uptime-com/uptime-client-go/pull/23)