### PR TITLE
feat(SYS-800): add ipv6, ipv4_addresses, and ipv6_addresses fields

### DIFF
--- a/docs/data-sources/locations.md
+++ b/docs/data-sources/locations.md
@@ -27,6 +27,9 @@ Read-Only:
 
 - `id` (String)
 - `ip` (String)
+- `ipv4_addresses` (List of String)
+- `ipv6` (String)
+- `ipv6_addresses` (List of String)
 - `location` (String)
 - `name` (String)
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.10.0
-	github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250422131219-888f91b5b6c3
+	github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250530091338-6a05c1423013
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250422131219-888f91b5b6c3 h1:+JUfGvRJFPVUDQ5keSqLxAFYLbFddV1dwNhyP9jBMmQ=
 github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250422131219-888f91b5b6c3/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
+github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250530091338-6a05c1423013 h1:sCf1z8j2F24AS+63rt4uKZBhz5nTBmxL4vbeV5Ew/d0=
+github.com/uptime-com/uptime-client-go/v2 v2.0.0-20250530091338-6a05c1423013/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/data_locations_test.go
+++ b/internal/provider/data_locations_test.go
@@ -15,6 +15,14 @@ func TestAccLocationsDataSource(t *testing.T) {
 		{
 			ConfigDirectory: config.StaticDirectory("testdata/data_locations"),
 			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttrWith("data.uptime_locations.test", "locations.0.ip",
+					func(value string) error {
+						if value == "" {
+							return errors.New("host_ip property is empty")
+						}
+						return nil
+					},
+				),
 				resource.TestCheckResourceAttrWith("data.uptime_locations.test", "locations.#",
 					func(value string) error {
 						n, err := strconv.Atoi(value)
@@ -23,6 +31,41 @@ func TestAccLocationsDataSource(t *testing.T) {
 						}
 						if n < 3 {
 							return errors.New("expected at least 3 locations")
+						}
+						return nil
+					},
+				),
+			),
+		},
+	}))
+}
+
+func TestAccLocationsDataSourceNewFields(t *testing.T) {
+	resource.Test(t, testCaseFromSteps(t, []resource.TestStep{
+		{
+			ConfigDirectory: config.StaticDirectory("testdata/data_locations"),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttrWith("data.uptime_locations.test", "locations.0.ipv4_addresses.#",
+					func(value string) error {
+						n, err := strconv.Atoi(value)
+						if err != nil {
+							return fmt.Errorf("failed to parse ipv4_addresses count: %w", err)
+						}
+						if n < 1 {
+							return errors.New("expected at least 1 IPv4 address")
+						}
+						return nil
+					},
+				),
+				resource.TestCheckResourceAttrSet("data.uptime_locations.test", "locations.0.ipv4_addresses.0"),
+				resource.TestCheckResourceAttrWith("data.uptime_locations.test", "locations.0.ipv6_addresses.#",
+					func(value string) error {
+						n, err := strconv.Atoi(value)
+						if err != nil {
+							return fmt.Errorf("failed to parse ipv6_addresses count: %w", err)
+						}
+						if n < 1 {
+							return errors.New("expected at least 1 IPv6 address")
 						}
 						return nil
 					},


### PR DESCRIPTION
- Extended LocationsDataSource and its schema with support for `ipv6`, `ipv4_addresses`, and `ipv6_addresses` fields.
- Updated logic to extract both primary and all associated IP addresses (IPv4/IPv6) from the API response.
- Added test coverage to verify new location address fields are populated.