### PR TITLE
fix: handle unknown/null values in RawJsonType.ToTerraformValue

### DIFF
--- a/internal/provider/attr_script.go
+++ b/internal/provider/attr_script.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 
@@ -28,7 +27,7 @@ func (s scriptValidator) ValidateString(_ context.Context, rq validator.StringRe
 	if rq.ConfigValue.IsNull() || rq.ConfigValue.IsUnknown() {
 		return
 	}
-	if !json.Valid(bytes.NewBufferString(rq.ConfigValue.String()).Bytes()) {
+	if !json.Valid([]byte(rq.ConfigValue.ValueString())) {
 		rs.Diagnostics.AddAttributeError(
 			rq.Path,
 			"Script must be valid JSON",

--- a/internal/provider/type_rawjson.go
+++ b/internal/provider/type_rawjson.go
@@ -197,6 +197,12 @@ func (v rawJsonValue) StringSemanticEquals(_ context.Context, val basetypes.Stri
 
 // ToTerraformValue returns a tftypes.Value representation of the value.
 func (v rawJsonValue) ToTerraformValue(context.Context) (tftypes.Value, error) {
+	if v.IsUnknown() {
+		return tftypes.NewValue(tftypes.String, tftypes.UnknownValue), nil
+	}
+	if v.IsNull() {
+		return tftypes.NewValue(tftypes.String, nil), nil
+	}
 	return tftypes.NewValue(tftypes.String, v.value), nil
 }
 


### PR DESCRIPTION
The ToTerraformValue method was incorrectly returning a known empty string when the rawJsonValue was in an unknown or null state. This caused validation to fail during terraform plan when script values contained computed/unknown values (e.g., from random_* resources or other computed attributes).