### PR TITLE
fix: add UseStateForUnknown plan modifier to url and sla attributes

### DIFF
--- a/internal/provider/attr.go
+++ b/internal/provider/attr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/uptime-com/uptime-client-go/v2/pkg/upapi"
@@ -34,6 +35,9 @@ func ComputedIDSchemaAttribute() schema.Int64Attribute {
 func URLSchemaAttribute() schema.StringAttribute {
 	return schema.StringAttribute{
 		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
 	}
 }
 

--- a/internal/provider/attr_sla.go
+++ b/internal/provider/attr_sla.go
@@ -6,6 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -19,6 +21,9 @@ func SLASchemaAttribute() schema.SingleNestedAttribute {
 		},
 		Optional: true,
 		Computed: true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	}
 }
 

--- a/internal/provider/attr_sla_latency.go
+++ b/internal/provider/attr_sla_latency.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
@@ -17,6 +19,9 @@ func SLALatencySchemaAttribute() schema.StringAttribute {
 			slaLatencyValidator{},
 		},
 		CustomType: DurationType,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
 	}
 }
 

--- a/internal/provider/attr_sla_uptime.go
+++ b/internal/provider/attr_sla_uptime.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 func SLAUptimeSchemaAttribute() schema.StringAttribute {
@@ -11,5 +13,8 @@ func SLAUptimeSchemaAttribute() schema.StringAttribute {
 		Optional:   true,
 		Computed:   true,
 		CustomType: DecimalType,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
 	}
 }


### PR DESCRIPTION
## Problem

`url`, `sla`, `sla.latency`, and `sla.uptime` show as `(known after apply)` on every `terraform plan` for any resource that uses `URLSchemaAttribute()` / `SLASchemaAttribute()` (most check resources, including `uptime_check_http`). Apply is a no-op server-side, pure plan noise that obscures real diffs.

Reproduction with `uptime_check_http`:

```
~ resource "uptime_check_http" "frontend" {
    id                        = 5707156
    name                      = "Frontend"
  ~ sla                       = {
      ~ latency = "0s" -> (known after apply)
        # (1 unchanged attribute hidden)
    }
  ~ url                       = "https://uptime.com/api/v1/checks/5707156/" -> (known after apply)
    # (21 unchanged attributes hidden)
}
```

## Fix

Add `UseStateForUnknown` plan modifiers to the four affected attributes:

- `URLSchemaAttribute()`
- `SLASchemaAttribute()`
- `SLALatencySchemaAttribute()`
- `SLAUptimeSchemaAttribute()`

Same one-line fix pattern as #213 (which added `UseStateForUnknown` to `IDSchemaAttribute()` in v2.23.0).
