### PR TITLE
fix(service_variable): detect UI deletion of credential link on refresh

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -43,7 +43,7 @@ jobs:
         env:
           TF_ACC: "yup"
           UPTIME_TOKEN: "${{ secrets.UPTIME_TOKEN }}"
-          UPTIME_RATE_LIMIT: "1.0"
+          UPTIME_RATE_LIMIT: "0.66"
         run: go test -test.timeout=50m -test.parallel=1 -v ./... -run ^TestAcc[A-Z]
 
   release:

--- a/internal/provider/api.go
+++ b/internal/provider/api.go
@@ -12,10 +12,20 @@ import (
 	"github.com/uptime-com/uptime-client-go/v2/pkg/upapi"
 )
 
-// isNotFoundError reports whether err represents an HTTP 404 response from the
-// Uptime.com API. It is used during refresh to detect resources that were
-// deleted out-of-band so they can be dropped from state instead of failing.
+// errResourceGone signals that the API returned a record that still exists at
+// the HTTP level but is logically deleted (e.g. carries a deleted_at marker).
+// A resource Read may return it, wrapped or not, to have the resource dropped
+// from state exactly like a 404 so out-of-band deletions surface as drift.
+var errResourceGone = errors.New("resource marked deleted by API")
+
+// isNotFoundError reports whether err represents a resource that no longer
+// exists: either an HTTP 404 response from the Uptime.com API or an
+// errResourceGone marker. It is used during refresh to detect resources that
+// were deleted out-of-band so they can be dropped from state instead of failing.
 func isNotFoundError(err error) bool {
+	if errors.Is(err, errResourceGone) {
+		return true
+	}
 	var apiErr *upapi.Error
 	if errors.As(err, &apiErr) {
 		return apiErr.Response != nil && apiErr.Response.StatusCode == http.StatusNotFound
@@ -23,16 +33,17 @@ func isNotFoundError(err error) bool {
 	return false
 }
 
-// notFoundWarning surfaces a 404-triggered state removal in the plan output.
-// A 404 can also mean a wrong subaccount/endpoint configuration, in which case
-// silently dropping resources would cascade into recreating everything.
+// notFoundWarning surfaces a state removal in the plan output. It fires when the
+// API reports a resource as gone (a 404, or a deleted_at marker). A 404 can also
+// mean a wrong subaccount/endpoint configuration, in which case silently dropping
+// resources would cascade into recreating everything.
 func notFoundWarning(typeNameSuffix string, pk upapi.PrimaryKeyable) diag.Diagnostic {
 	return diag.NewWarningDiagnostic(
 		"Resource Not Found",
 		fmt.Sprintf(
-			"uptime_%s with ID %d returned 404 and was removed from state. "+
-				"If the resource was not deleted out-of-band, check the provider's "+
-				"subaccount and endpoint configuration before applying.",
+			"uptime_%s with ID %d no longer exists on the server and was removed "+
+				"from state. If the resource was not deleted out-of-band, check the "+
+				"provider's subaccount and endpoint configuration before applying.",
 			typeNameSuffix, pk.PrimaryKey(),
 		),
 	)
@@ -60,9 +71,20 @@ type APIModeler[M APIModel, A, R any] interface {
 }
 
 // PlanValuePreserver is an optional interface that APIModelers can implement
-// to preserve plan values for fields that the API does not return.
+// to preserve plan values for fields that the API does not return. It is applied
+// on Create and Update (apply time), and on Read unless the modeler also
+// implements ReadValuePreserver.
 type PlanValuePreserver[M APIModel] interface {
 	PreservePlanValues(result *M, plan *M) *M
+}
+
+// ReadValuePreserver is an optional interface that APIModelers can implement to
+// override how prior state is reconciled with the API response on Read only.
+// When implemented, Read calls PreserveReadValues instead of PreservePlanValues,
+// letting a resource trust the server response on refresh so out-of-band changes
+// surface as drift.
+type ReadValuePreserver[M APIModel] interface {
+	PreserveReadValues(result *M, state *M) *M
 }
 
 type APIResourceMetadata struct {
@@ -175,8 +197,12 @@ func (r APIResource[M, A, R]) Read(ctx context.Context, rq resource.ReadRequest,
 		return
 	}
 
-	// Preserve state values for fields that the API doesn't return
-	if preserver, ok := any(r.mod).(PlanValuePreserver[M]); ok {
+	// On refresh, prefer a Read-specific reconciler when the modeler provides one
+	// (it may trust the API to surface out-of-band drift); otherwise fall back to
+	// the apply-time plan-value preservation for fields the API doesn't return.
+	if preserver, ok := any(r.mod).(ReadValuePreserver[M]); ok {
+		resultModel = preserver.PreserveReadValues(resultModel, stateModel)
+	} else if preserver, ok := any(r.mod).(PlanValuePreserver[M]); ok {
 		resultModel = preserver.PreservePlanValues(resultModel, stateModel)
 	}
 

--- a/internal/provider/api_test.go
+++ b/internal/provider/api_test.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/uptime-com/uptime-client-go/v2/pkg/upapi"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "resource gone sentinel",
+			err:  errResourceGone,
+			want: true,
+		},
+		{
+			name: "wrapped resource gone sentinel",
+			err:  fmt.Errorf("read failed: %w", errResourceGone),
+			want: true,
+		},
+		{
+			name: "http 404",
+			err:  &upapi.Error{Response: &http.Response{StatusCode: http.StatusNotFound}},
+			want: true,
+		},
+		{
+			name: "http 500",
+			err:  &upapi.Error{Response: &http.Response{StatusCode: http.StatusInternalServerError}},
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNotFoundError(tt.err); got != tt.want {
+				t.Errorf("isNotFoundError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/resource_service_variable.go
+++ b/internal/provider/resource_service_variable.go
@@ -121,10 +121,12 @@ func (a ServiceVariableResourceModelAdapter) FromAPIResult(api ServiceVariableWr
 	}, nil
 }
 
-// PreservePlanValues restores credential_id, property_name and variable_name from the
-// plan (or prior state on Read) when the API response omits them. These are Required
-// attributes, so an empty 0/"" result mismatches the planned value and trips "Provider
-// produced inconsistent result after apply".
+// PreservePlanValues restores credential_id, property_name and variable_name from
+// the plan when the API response omits them. These are Required attributes, so an
+// empty 0/"" result mismatches the planned value and trips "Provider produced
+// inconsistent result after apply". This runs at apply time only (Create/Update);
+// PreserveReadValues deliberately opts refresh out of this backfill so that
+// out-of-band deletions are not masked.
 func (a ServiceVariableResourceModelAdapter) PreservePlanValues(result, plan *ServiceVariableResourceModel) *ServiceVariableResourceModel {
 	if result.CredentialID.ValueInt64() == 0 {
 		result.CredentialID = plan.CredentialID
@@ -135,6 +137,13 @@ func (a ServiceVariableResourceModelAdapter) PreservePlanValues(result, plan *Se
 	if result.VariableName.ValueString() == "" {
 		result.VariableName = plan.VariableName
 	}
+	return result
+}
+
+// PreserveReadValues trusts the API response on refresh: it does not backfill from
+// prior state. Combined with the deleted_at handling in Read, this lets a UI-side
+// removal of the credential link show up as drift instead of being silently masked.
+func (a ServiceVariableResourceModelAdapter) PreserveReadValues(result, _ *ServiceVariableResourceModel) *ServiceVariableResourceModel {
 	return result
 }
 
@@ -169,6 +178,12 @@ func (c ServiceVariableResourceAPI) Read(ctx context.Context, pk upapi.PrimaryKe
 	result, err := c.provider.api.ServiceVariables().Get(ctx, pk)
 	if err != nil {
 		return nil, err
+	}
+	// The API keeps returning the link after it is unbound in the UI, only
+	// flagging it with deleted_at. Treat that as gone so the deletion surfaces
+	// as drift instead of being masked by the apply-time backfill.
+	if result.DeletedAt != nil {
+		return nil, errResourceGone
 	}
 	// Extract credential_id from nested credential object if not at top level
 	if result.CredentialID == 0 && result.Credential != nil {

--- a/internal/provider/resource_service_variable_test.go
+++ b/internal/provider/resource_service_variable_test.go
@@ -1,12 +1,16 @@
 package provider
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/uptime-com/uptime-client-go/v2/pkg/upapi"
 )
 
 // TestServiceVariablePreservePlanValues verifies that Required attributes the update
@@ -57,6 +61,101 @@ func TestServiceVariablePreservePlanValues(t *testing.T) {
 			t.Errorf("variable_name: got %q, want \"other_name\"", got.VariableName.ValueString())
 		}
 	})
+}
+
+// TestServiceVariablePreserveReadValues verifies that refresh trusts the API and does
+// not backfill from prior state, so a UI-side removal of the credential link (which the
+// API reports as empty) surfaces as drift instead of being masked (SYS-1284).
+func TestServiceVariablePreserveReadValues(t *testing.T) {
+	adapter := ServiceVariableResourceModelAdapter{}
+
+	state := &ServiceVariableResourceModel{
+		CredentialID: types.Int64Value(28966),
+		PropertyName: types.StringValue("secret"),
+		VariableName: types.StringValue("token_raven_token"),
+	}
+	result := &ServiceVariableResourceModel{
+		CredentialID: types.Int64Value(0),
+		PropertyName: types.StringValue(""),
+		VariableName: types.StringValue(""),
+	}
+
+	got := adapter.PreserveReadValues(result, state)
+	if got.CredentialID.ValueInt64() != 0 {
+		t.Errorf("credential_id: got %d, want 0 (must not backfill from state)", got.CredentialID.ValueInt64())
+	}
+	if got.PropertyName.ValueString() != "" {
+		t.Errorf("property_name: got %q, want \"\" (must not backfill from state)", got.PropertyName.ValueString())
+	}
+	if got.VariableName.ValueString() != "" {
+		t.Errorf("variable_name: got %q, want \"\" (must not backfill from state)", got.VariableName.ValueString())
+	}
+}
+
+// stubServiceVariablesAPI embeds upapi.API and overrides only ServiceVariables so
+// the Read path can be exercised without a live client. The embedded endpoint
+// leaves every method but Get unimplemented (they panic if called).
+type stubServiceVariablesAPI struct {
+	upapi.API
+	get *upapi.ServiceVariable
+}
+
+func (s stubServiceVariablesAPI) ServiceVariables() upapi.ServiceVariablesEndpoint {
+	return stubServiceVariablesEndpoint{get: s.get}
+}
+
+type stubServiceVariablesEndpoint struct {
+	upapi.ServiceVariablesEndpoint
+	get *upapi.ServiceVariable
+}
+
+func (s stubServiceVariablesEndpoint) Get(context.Context, upapi.PrimaryKeyable) (*upapi.ServiceVariable, error) {
+	return s.get, nil
+}
+
+// TestServiceVariableReadDeletedDrift verifies that a link the API reports as
+// soft-deleted (deleted_at set) is treated as gone on refresh, so the deletion
+// surfaces as drift instead of being masked by the backfill (SYS-1284).
+func TestServiceVariableReadDeletedDrift(t *testing.T) {
+	deletedAt := time.Unix(1_700_000_000, 0)
+	api := ServiceVariableResourceAPI{provider: &providerImpl{
+		api: stubServiceVariablesAPI{get: &upapi.ServiceVariable{ID: 42, DeletedAt: &deletedAt}},
+	}}
+
+	_, err := api.Read(context.Background(), ServiceVariableResourceModel{ID: types.Int64Value(42)})
+	if !errors.Is(err, errResourceGone) {
+		t.Fatalf("Read of deleted link: got err %v, want errResourceGone", err)
+	}
+	if !isNotFoundError(err) {
+		t.Errorf("isNotFoundError(%v) = false, want true so the resource is dropped from state", err)
+	}
+}
+
+// TestServiceVariableReadLive verifies that a live link is returned as-is and, when
+// credential_id is only present in the nested credential object, is recovered from it.
+func TestServiceVariableReadLive(t *testing.T) {
+	api := ServiceVariableResourceAPI{provider: &providerImpl{
+		api: stubServiceVariablesAPI{get: &upapi.ServiceVariable{
+			ID:           42,
+			Credential:   &upapi.ServiceVariableCredential{ID: 99},
+			PropertyName: "password",
+			VariableName: "api_password",
+		}},
+	}}
+
+	got, err := api.Read(context.Background(), ServiceVariableResourceModel{
+		ID:        types.Int64Value(42),
+		ServiceID: types.Int64Value(7),
+	})
+	if err != nil {
+		t.Fatalf("Read of live link: unexpected error %v", err)
+	}
+	if got.CredentialID != 99 {
+		t.Errorf("credential_id: got %d, want 99 (recovered from nested credential)", got.CredentialID)
+	}
+	if got.ServiceID != 7 {
+		t.Errorf("service_id: got %d, want 7 (preserved from prior state)", got.ServiceID)
+	}
 }
 
 func TestAccServiceVariableResource(t *testing.T) {


### PR DESCRIPTION
The check<->credential link (uptime_service_variable) backfilled empty API fields from prior state on every read. That workaround was meant for apply time, but running it on refresh masked UI-side deletions: the API returns the link with a deleted_at marker, the provider restored it from state, and terraform plan reported no drift.

Read now returns a resource-gone marker when deleted_at is set, so the link is dropped from state and the deletion surfaces as drift. The apply-time backfill is kept but scoped to Create/Update via a new optional ReadValuePreserver interface, so refresh trusts the server response.

SYS-1284