### PR TITLE
fix(statuspage): expose INSPIRE-theme custom branding fields

### DIFF
--- a/docs/resources/statuspage.md
+++ b/docs/resources/statuspage.md
@@ -56,10 +56,13 @@ resource "uptime_statuspage" "public" {
 - `cname` (String)
 - `company_website_url` (String)
 - `contact_email` (String)
-- `custom_css` (String)
-- `custom_footer_html` (String)
+- `custom_css` (String) Custom CSS rendered only under the LEGACY theme. API-managed status pages use the INSPIRE theme, so use custom_css_inspire instead.
+- `custom_css_inspire` (String) Custom CSS rendered on the status page under the INSPIRE theme (the theme used by all API-managed status pages).
+- `custom_footer_html` (String) Custom footer HTML rendered only under the LEGACY theme. API-managed status pages use the INSPIRE theme, so use custom_footer_html_inspire instead.
+- `custom_footer_html_inspire` (String) Custom footer HTML rendered on the status page under the INSPIRE theme (the theme used by all API-managed status pages).
 - `custom_header_bg_color_hex` (String)
-- `custom_header_html` (String)
+- `custom_header_html` (String) Custom header HTML rendered only under the LEGACY theme. API-managed status pages use the INSPIRE theme, so use custom_header_html_inspire instead.
+- `custom_header_html_inspire` (String) Custom header HTML rendered on the status page under the INSPIRE theme (the theme used by all API-managed status pages).
 - `custom_header_text_color_hex` (String)
 - `default_history_date_range` (Number)
 - `description` (String)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.11.1
-	github.com/uptime-com/uptime-client-go/v2 v2.14.0
+	github.com/uptime-com/uptime-client-go/v2 v2.14.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/uptime-com/uptime-client-go/v2 v2.14.0 h1:VK8B9IDktdHGmq4s/Uwh5DDQOsEaVeZOxfxrP2QE1bY=
-github.com/uptime-com/uptime-client-go/v2 v2.14.0/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
+github.com/uptime-com/uptime-client-go/v2 v2.14.1 h1:tC8XUUHjJCZUSYL1UUWZ2As8QBrUmVOlV0hx3KPsu5E=
+github.com/uptime-com/uptime-client-go/v2 v2.14.1/go.mod h1:jtWeB/tQ00fLX2r9OwKfTnxQ/PMR0YjmhTuc9RZH2h0=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resource_statuspage.go
+++ b/internal/provider/resource_statuspage.go
@@ -174,16 +174,55 @@ func NewStatusPageResource(_ context.Context, p *providerImpl) resource.Resource
 						Default:  stringdefault.StaticString(""),
 					},
 					"custom_header_html": schema.StringAttribute{
+						Description: "Custom header HTML rendered only under the LEGACY theme. " +
+							"API-managed status pages use the INSPIRE theme, so use " +
+							"custom_header_html_inspire instead.",
 						Optional: true,
 						Computed: true,
 						Default:  stringdefault.StaticString(""),
+						Validators: []validator.String{
+							LegacyOnlyBrandingWarningValidator("custom_header_html_inspire"),
+						},
 					},
 					"custom_footer_html": schema.StringAttribute{
+						Description: "Custom footer HTML rendered only under the LEGACY theme. " +
+							"API-managed status pages use the INSPIRE theme, so use " +
+							"custom_footer_html_inspire instead.",
+						Optional: true,
+						Computed: true,
+						Default:  stringdefault.StaticString(""),
+						Validators: []validator.String{
+							LegacyOnlyBrandingWarningValidator("custom_footer_html_inspire"),
+						},
+					},
+					"custom_css": schema.StringAttribute{
+						Description: "Custom CSS rendered only under the LEGACY theme. " +
+							"API-managed status pages use the INSPIRE theme, so use " +
+							"custom_css_inspire instead.",
+						Optional: true,
+						Computed: true,
+						Default:  stringdefault.StaticString(""),
+						Validators: []validator.String{
+							LegacyOnlyBrandingWarningValidator("custom_css_inspire"),
+						},
+					},
+					"custom_header_html_inspire": schema.StringAttribute{
+						Description: "Custom header HTML rendered on the status page under the " +
+							"INSPIRE theme (the theme used by all API-managed status pages).",
 						Optional: true,
 						Computed: true,
 						Default:  stringdefault.StaticString(""),
 					},
-					"custom_css": schema.StringAttribute{
+					"custom_footer_html_inspire": schema.StringAttribute{
+						Description: "Custom footer HTML rendered on the status page under the " +
+							"INSPIRE theme (the theme used by all API-managed status pages).",
+						Optional: true,
+						Computed: true,
+						Default:  stringdefault.StaticString(""),
+					},
+					"custom_css_inspire": schema.StringAttribute{
+						Description: "Custom CSS rendered on the status page under the INSPIRE " +
+							"theme (the theme used by all API-managed status pages).",
 						Optional: true,
 						Computed: true,
 						Default:  stringdefault.StaticString(""),
@@ -283,6 +322,9 @@ type StatusPageResourceModel struct {
 	CustomHeaderHtml          types.String `tfsdk:"custom_header_html"`
 	CustomFooterHtml          types.String `tfsdk:"custom_footer_html"`
 	CustomCss                 types.String `tfsdk:"custom_css"`
+	CustomHeaderHtmlInspire   types.String `tfsdk:"custom_header_html_inspire"`
+	CustomFooterHtmlInspire   types.String `tfsdk:"custom_footer_html_inspire"`
+	CustomCssInspire          types.String `tfsdk:"custom_css_inspire"`
 	CompanyWebsiteUrl         types.String `tfsdk:"company_website_url"`
 	Timezone                  types.String `tfsdk:"timezone"`
 	AllowSubscriptionsEmail   types.Bool   `tfsdk:"allow_subscriptions_email"`
@@ -343,6 +385,9 @@ func (c StatusPageResourceModelAdapter) ToAPIArgument(model StatusPageResourceMo
 		CustomHeaderHtml:          model.CustomHeaderHtml.ValueString(),
 		CustomFooterHtml:          model.CustomFooterHtml.ValueString(),
 		CustomCss:                 model.CustomCss.ValueString(),
+		CustomHeaderHtmlInspire:   model.CustomHeaderHtmlInspire.ValueString(),
+		CustomFooterHtmlInspire:   model.CustomFooterHtmlInspire.ValueString(),
+		CustomCssInspire:          model.CustomCssInspire.ValueString(),
 		CompanyWebsiteUrl:         model.CompanyWebsiteUrl.ValueString(),
 		Timezone:                  model.Timezone.ValueString(),
 		AllowSubscriptionsEmail:   model.AllowSubscriptionsEmail.ValueBool(),
@@ -392,6 +437,9 @@ func (c StatusPageResourceModelAdapter) FromAPIResult(api upapi.StatusPage) (*St
 		CustomHeaderHtml:          types.StringValue(api.CustomHeaderHtml),
 		CustomFooterHtml:          types.StringValue(api.CustomFooterHtml),
 		CustomCss:                 types.StringValue(api.CustomCss),
+		CustomHeaderHtmlInspire:   types.StringValue(api.CustomHeaderHtmlInspire),
+		CustomFooterHtmlInspire:   types.StringValue(api.CustomFooterHtmlInspire),
+		CustomCssInspire:          types.StringValue(api.CustomCssInspire),
 		CompanyWebsiteUrl:         types.StringValue(api.CompanyWebsiteUrl),
 		Timezone:                  types.StringValue(api.Timezone),
 		AllowSubscriptionsEmail:   types.BoolValue(api.AllowSubscriptionsEmail),

--- a/internal/provider/resource_statuspage_test.go
+++ b/internal/provider/resource_statuspage_test.go
@@ -4,9 +4,52 @@ import (
 	"testing"
 
 	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uptime-com/uptime-client-go/v2/pkg/upapi"
 )
+
+// TestStatusPageAdapterCustomBrandingRoundTrip pins the mapping of the LEGACY and
+// INSPIRE custom-branding fields in both directions. Distinct values per field
+// guard against copy-paste swaps between the near-identical mapping lines.
+func TestStatusPageAdapterCustomBrandingRoundTrip(t *testing.T) {
+	a := StatusPageResourceModelAdapter{}
+	m := StatusPageResourceModel{
+		CustomHeaderHtml:        types.StringValue("legacy-header"),
+		CustomFooterHtml:        types.StringValue("legacy-footer"),
+		CustomCss:               types.StringValue("legacy-css"),
+		CustomHeaderHtmlInspire: types.StringValue("inspire-header"),
+		CustomFooterHtmlInspire: types.StringValue("inspire-footer"),
+		CustomCssInspire:        types.StringValue("inspire-css"),
+	}
+	arg, err := a.ToAPIArgument(m)
+	require.NoError(t, err)
+	require.Equal(t, "legacy-header", arg.CustomHeaderHtml)
+	require.Equal(t, "legacy-footer", arg.CustomFooterHtml)
+	require.Equal(t, "legacy-css", arg.CustomCss)
+	require.Equal(t, "inspire-header", arg.CustomHeaderHtmlInspire)
+	require.Equal(t, "inspire-footer", arg.CustomFooterHtmlInspire)
+	require.Equal(t, "inspire-css", arg.CustomCssInspire)
+
+	back, err := a.FromAPIResult(upapi.StatusPage{
+		CustomHeaderHtml:        "legacy-header",
+		CustomFooterHtml:        "legacy-footer",
+		CustomCss:               "legacy-css",
+		CustomHeaderHtmlInspire: "inspire-header",
+		CustomFooterHtmlInspire: "inspire-footer",
+		CustomCssInspire:        "inspire-css",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "legacy-header", back.CustomHeaderHtml.ValueString())
+	require.Equal(t, "legacy-footer", back.CustomFooterHtml.ValueString())
+	require.Equal(t, "legacy-css", back.CustomCss.ValueString())
+	require.Equal(t, "inspire-header", back.CustomHeaderHtmlInspire.ValueString())
+	require.Equal(t, "inspire-footer", back.CustomFooterHtmlInspire.ValueString())
+	require.Equal(t, "inspire-css", back.CustomCssInspire.ValueString())
+}
 
 // TODO: Extend the test to cover more fields
 func TestAccStatusPageResource(t *testing.T) {
@@ -73,6 +116,9 @@ func TestAccStatusPageExtendedResource(t *testing.T) {
 					"theme":                        config.StringVariable("INSPIRE"),
 					"custom_header_bg_color_hex":   config.StringVariable("#000000"),
 					"custom_header_text_color_hex": config.StringVariable("#FFFFFF"),
+					"custom_header_html_inspire":   config.StringVariable("<header>hello</header>"),
+					"custom_footer_html_inspire":   config.StringVariable("<footer>bye</footer>"),
+					"custom_css_inspire":           config.StringVariable("color: red;"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("uptime_statuspage.test", "name", names[0]),
@@ -86,6 +132,9 @@ func TestAccStatusPageExtendedResource(t *testing.T) {
 					resource.TestCheckResourceAttr("uptime_statuspage.test", "theme", "INSPIRE"),
 					resource.TestCheckResourceAttr("uptime_statuspage.test", "custom_header_bg_color_hex", "#000000"),
 					resource.TestCheckResourceAttr("uptime_statuspage.test", "custom_header_text_color_hex", "#FFFFFF"),
+					resource.TestCheckResourceAttr("uptime_statuspage.test", "custom_header_html_inspire", "<header>hello</header>"),
+					resource.TestCheckResourceAttr("uptime_statuspage.test", "custom_footer_html_inspire", "<footer>bye</footer>"),
+					resource.TestCheckResourceAttr("uptime_statuspage.test", "custom_css_inspire", "color: red;"),
 				),
 			},
 			{
@@ -102,6 +151,9 @@ func TestAccStatusPageExtendedResource(t *testing.T) {
 					"theme":                        config.StringVariable("INSPIRE"),
 					"custom_header_bg_color_hex":   config.StringVariable("#FFFFFF"),
 					"custom_header_text_color_hex": config.StringVariable("#000000"),
+					"custom_header_html_inspire":   config.StringVariable(""),
+					"custom_footer_html_inspire":   config.StringVariable(""),
+					"custom_css_inspire":           config.StringVariable(""),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("uptime_statuspage.test", "name", names[1]),
@@ -115,6 +167,9 @@ func TestAccStatusPageExtendedResource(t *testing.T) {
 					resource.TestCheckResourceAttr("uptime_statuspage.test", "theme", "INSPIRE"),
 					resource.TestCheckResourceAttr("uptime_statuspage.test", "custom_header_bg_color_hex", "#FFFFFF"),
 					resource.TestCheckResourceAttr("uptime_statuspage.test", "custom_header_text_color_hex", "#000000"),
+					resource.TestCheckResourceAttr("uptime_statuspage.test", "custom_header_html_inspire", ""),
+					resource.TestCheckResourceAttr("uptime_statuspage.test", "custom_footer_html_inspire", ""),
+					resource.TestCheckResourceAttr("uptime_statuspage.test", "custom_css_inspire", ""),
 				),
 			},
 		},

--- a/internal/provider/testdata/resource_statuspage/extended/main.tf
+++ b/internal/provider/testdata/resource_statuspage/extended/main.tf
@@ -42,6 +42,18 @@ variable "custom_header_text_color_hex" {
   type = string
 }
 
+variable "custom_header_html_inspire" {
+  type = string
+}
+
+variable "custom_footer_html_inspire" {
+  type = string
+}
+
+variable "custom_css_inspire" {
+  type = string
+}
+
 resource "uptime_statuspage" "test" {
   name                         = var.name
   allow_subscriptions_email    = var.allow_subscriptions_email
@@ -54,4 +66,7 @@ resource "uptime_statuspage" "test" {
   theme                        = var.theme
   custom_header_bg_color_hex   = var.custom_header_bg_color_hex
   custom_header_text_color_hex = var.custom_header_text_color_hex
+  custom_header_html_inspire   = var.custom_header_html_inspire
+  custom_footer_html_inspire   = var.custom_footer_html_inspire
+  custom_css_inspire           = var.custom_css_inspire
 }

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -62,6 +62,35 @@ func (v *oneOfStringValidator) ValidateString(_ context.Context, rq validator.St
 	}
 }
 
+// LegacyOnlyBrandingWarningValidator warns that a status page custom-branding
+// field is rendered only under the LEGACY theme. Status pages managed through the
+// Uptime API always use the INSPIRE theme, so setting this field is stored but has
+// no visible effect; the caller should set the *_inspire variant instead.
+func LegacyOnlyBrandingWarningValidator(inspireAttr string) validator.String {
+	return legacyOnlyBrandingWarningValidator{inspireAttr: inspireAttr}
+}
+
+type legacyOnlyBrandingWarningValidator struct {
+	zoyaDescriber
+	inspireAttr string
+}
+
+func (v legacyOnlyBrandingWarningValidator) ValidateString(_ context.Context, rq validator.StringRequest, rs *validator.StringResponse) {
+	if rq.ConfigValue.IsNull() || rq.ConfigValue.IsUnknown() || rq.ConfigValue.ValueString() == "" {
+		return
+	}
+	rs.Diagnostics.AddAttributeWarning(
+		rq.Path,
+		"Custom branding is not rendered under the INSPIRE theme",
+		fmt.Sprintf(
+			"Status pages managed through the Uptime API always use the INSPIRE theme, "+
+				"which renders only the %q attribute. The value set here is stored but will "+
+				"not be displayed on the status page. Set %q instead to apply custom branding.",
+			v.inspireAttr, v.inspireAttr,
+		),
+	)
+}
+
 func HostnameValidator() validator.String {
 	return hostnameValidator{}
 }

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -1,0 +1,43 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestLegacyOnlyBrandingWarningValidator(t *testing.T) {
+	cases := map[string]struct {
+		value       types.String
+		wantWarning bool
+	}{
+		"non-empty value warns":   {types.StringValue("<header/>"), true},
+		"empty value is silent":   {types.StringValue(""), false},
+		"null value is silent":    {types.StringNull(), false},
+		"unknown value is silent": {types.StringUnknown(), false},
+	}
+	v := LegacyOnlyBrandingWarningValidator("custom_header_html_inspire")
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rq := validator.StringRequest{Path: path.Root("custom_header_html"), ConfigValue: tc.value}
+			rs := &validator.StringResponse{}
+			v.ValidateString(context.Background(), rq, rs)
+			if rs.Diagnostics.HasError() {
+				t.Fatalf("validator must never emit an error, got: %v", rs.Diagnostics)
+			}
+			if got := rs.Diagnostics.WarningsCount() > 0; got != tc.wantWarning {
+				t.Fatalf("warning = %v, want %v", got, tc.wantWarning)
+			}
+			if tc.wantWarning {
+				detail := rs.Diagnostics.Warnings()[0].Detail()
+				if !strings.Contains(detail, "custom_header_html_inspire") {
+					t.Fatalf("warning must point to the *_inspire attribute, got: %q", detail)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Status pages managed through the Uptime API always use the INSPIRE theme, which renders only the custom_header_html_inspire / custom_footer_html_inspire / custom_css_inspire fields. The provider previously mapped only the plain custom_header_html / custom_footer_html / custom_css fields, which render solely under the LEGACY theme. As a result, apply succeeded but the branding never appeared on the page, and UI edits (which land in the *_inspire fields) produced no drift.

Add the three *_inspire attributes and map them through ToAPIArgument / FromAPIResult. Add a plan-time warning on the plain custom_* attributes pointing users to the *_inspire variant, and document the distinction.