### PR TITLE
Fix HTTP header case canonicalization in uptime_check_http (#250)

### DIFF
--- a/docs/resources/check_http.md
+++ b/docs/resources/check_http.md
@@ -90,9 +90,10 @@ Set to an empty list to disable notifications at this level and rely on parent c
 - `encryption` (String) Whether to verify SSL/TLS certificates
 - `expect_string` (String)
 - `expect_string_type` (String) Valid values for this property are: "STRING" - exact match, "REGEX" - match by regular expression, "INVERSE_REGEX" - fail if the regular expression matches
-- `headers` (Map of List of String) A map of HTTP headers where each header name maps to a list of values. 
-Header names are case-insensitive. Multiple values for the same header are supported 
-(e.g., { 'Accept': ['application/json', 'text/plain'] }). Defaults to an empty map if not specified.
+- `headers` (Map of List of String) A map of HTTP headers where each header name maps to a list of values.
+Header names are stored exactly as written; their casing is preserved. Multiple values for the
+same header are supported (e.g., { 'Accept': ['application/json', 'text/plain'] }). Defaults to an
+empty map if not specified.
 - `include_in_global_metrics` (Boolean) Include this check in uptime/response time calculations for the dashboard and status pages
 - `interval` (Number) The interval between checks in minutes
 - `is_paused` (Boolean)

--- a/internal/provider/attr_headers.go
+++ b/internal/provider/attr_headers.go
@@ -5,9 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
-	"net/textproto"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -15,14 +13,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/pkg/errors"
 )
 
 func HeadersSchemaAttribute() schema.Attribute {
 	return schema.MapAttribute{
-		Description: `A map of HTTP headers where each header name maps to a list of values. 
-Header names are case-insensitive. Multiple values for the same header are supported 
-(e.g., { 'Accept': ['application/json', 'text/plain'] }). Defaults to an empty map if not specified.`,
+		Description: `A map of HTTP headers where each header name maps to a list of values.
+Header names are stored exactly as written; their casing is preserved. Multiple values for the
+same header are supported (e.g., { 'Accept': ['application/json', 'text/plain'] }). Defaults to an
+empty map if not specified.`,
 		ElementType: types.ListType{
 			ElemType: types.StringType,
 		},
@@ -64,18 +62,26 @@ func (a HeadersAttributeAdapter) HeadersAttributeValue(in string) (types.Map, er
 	if strings.TrimSpace(in) == "" {
 		return types.MapValueMust(HeadersType.ElementType(), map[string]attr.Value{}), nil
 	}
-	tp := textproto.NewReader(bufio.NewReader(bytes.NewBufferString(in)))
-	header, err := tp.ReadMIMEHeader()
-	if err != nil && !errors.Is(err, io.EOF) {
+	values := make(map[string][]attr.Value)
+	scanner := bufio.NewScanner(strings.NewReader(in))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		idx := strings.IndexByte(line, ':')
+		if idx < 0 {
+			return types.MapNull(HeadersType.ElementType()), fmt.Errorf("malformed header line: %q", line)
+		}
+		name := line[:idx]
+		value := strings.TrimSpace(line[idx+1:])
+		values[name] = append(values[name], types.StringValue(value))
+	}
+	if err := scanner.Err(); err != nil {
 		return types.MapNull(HeadersType.ElementType()), err
 	}
-	elems := make(map[string]attr.Value)
-	for name := range header {
-		values := header.Values(name)
-		elem := make([]attr.Value, len(values))
-		for i := range values {
-			elem[i] = types.StringValue(values[i])
-		}
+	elems := make(map[string]attr.Value, len(values))
+	for name, elem := range values {
 		elems[name] = types.ListValueMust(types.StringType, elem)
 	}
 	return types.MapValueMust(HeadersType.ElementType(), elems), nil

--- a/internal/provider/attr_headers_test.go
+++ b/internal/provider/attr_headers_test.go
@@ -29,6 +29,12 @@ func TestHeadersAttributeAdapter_HeadersAttributeContext(t *testing.T) {
 				"Foo: Baz\r\n" +
 				"Qux: Quux\r\n",
 		},
+		"non-canonical case preserved": {
+			arg: types.MapValueMust(HeadersType.ElementType(), map[string]attr.Value{
+				"SOME-Header": types.ListValueMust(types.StringType, []attr.Value{types.StringValue("value1")}),
+			}),
+			expect: "SOME-Header: value1\r\n",
+		},
 		"null": {
 			arg: types.MapNull(HeadersType.ElementType()),
 		},
@@ -76,9 +82,20 @@ func TestHeadersAttributeAdapter_HeadersAttributeValue(t *testing.T) {
 				"Qux": types.ListValueMust(types.StringType, []attr.Value{types.StringValue("Quux")}),
 			}),
 		},
+		"non-canonical case preserved": {
+			arg: "SOME-Header: value1\r\n",
+			expect: types.MapValueMust(HeadersType.ElementType(), map[string]attr.Value{
+				"SOME-Header": types.ListValueMust(types.StringType, []attr.Value{types.StringValue("value1")}),
+			}),
+		},
 		"empty": {
 			arg:    "",
 			expect: types.MapValueMust(HeadersType.ElementType(), map[string]attr.Value{}),
+		},
+		"malformed": {
+			arg:         "no-colon-here\r\n",
+			expect:      types.MapNull(HeadersType.ElementType()),
+			expectError: true,
 		},
 	}
 

--- a/internal/provider/resource_check_http_test.go
+++ b/internal/provider/resource_check_http_test.go
@@ -228,6 +228,19 @@ func TestAccCheckHTTPResource_Headers(t *testing.T) {
 				resource.TestCheckResourceAttr("uptime_check_http.test", "headers.Qux.0", "Quux"),
 			),
 		},
+		{
+			ConfigDirectory: config.StaticDirectory("testdata/resource_check_http/headers"),
+			ConfigVariables: config.Variables{
+				"name": config.StringVariable(name),
+				"headers": config.MapVariable(map[string]config.Variable{
+					"SOME-Header": config.ListVariable(config.StringVariable("value1")),
+				}),
+			},
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("uptime_check_http.test", "headers.SOME-Header.#", "1"),
+				resource.TestCheckResourceAttr("uptime_check_http.test", "headers.SOME-Header.0", "value1"),
+			),
+		},
 	}))
 }
 


### PR DESCRIPTION
## Summary

Fixes #250. Applying an `uptime_check_http` resource with a non-canonical header name (e.g. `"SOME-Header"`) failed with `Provider produced inconsistent result after apply` (`element "SOME-Header" has vanished` / `new element "Some-Header" has appeared`).

## Root cause

Headers travel to the API as an opaque `string` blob (`msp_headers`), so the provider owns serialization. The write path (`HeadersAttributeContext` via `http.Header.Write`) preserves key casing, but the read path (`HeadersAttributeValue`) parsed the response with `textproto.ReadMIMEHeader`, which canonicalizes every key via `CanonicalMIMEHeaderKey` (`"SOME-Header"` -> `"Some-Header"`). Because `headers` is `Optional + Computed`, Terraform's plan/result consistency check rejected the changed case.

The secondary symptom in the issue thread (sensitive header values shown in plaintext on the next plan) was a downstream consequence of the resource being forced to churn/recreate, and is resolved by the same fix.

## Changes

- `internal/provider/attr_headers.go` - parse the header string manually (split on the first `:`, trim value), preserving the exact key casing the API echoes back. Removed the now-unused `textproto`/`io`/`pkg/errors` imports.
- `internal/provider/attr_headers.go` - corrected the schema description that wrongly claimed header names are case-insensitive; regenerated `docs/resources/check_http.md`.
- Tests - added non-canonical key (`SOME-Header`) round-trip coverage to the unit tests (both directions + malformed line) and a step to the `TestAccCheckHTTPResource_Headers` acceptance test.

## Verification

- `just test` - all unit tests pass, including the new case-preservation cases.
- `TestAccCheckHTTPResource_Headers` passes end-to-end against the real API: mixed-case key preserved, no inconsistency error.